### PR TITLE
Restructure the README for an upstream audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 <!--- specific language governing permissions and limitations -->
 <!--- under the License. -->
 
-
 <table>
   <tr>
     <td><img src="https://raw.githubusercontent.com/hamzaqureshi5/gsm-data-generator-gui/ds0/src/resources/icon_without_text.png" width="128"/></td>
@@ -29,142 +28,217 @@
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green)](LICENSE)
 
-[Documentation]() |
-[Contributors](CONTRIBUTORS.md) |
-[Community]() |
-[Release Notes](NEWS.md)
+GSM Data Generator produces the per-card material a SIM personalization run
+requires — identifiers, authentication keys and administrative codes — from a
+single declarative configuration, and emits it in the formats consumed by
+personalization equipment, laser marking systems and network provisioning.
 
-GSM Data Generator is a library for generating and processing structured datasets for GSM, USIM, and eSIM systems. It is designed to bridge the gap between telecom operator requirements and developer productivity, offering flexible tools for data parsing, formatting, and export. The library provides an extensible framework to define operator-specific templates, process large-scale inputs, and generate outputs in standardized formats for downstream telecom systems.
+It is intended for SIM manufacturers, MVNOs and test-lab engineers who need
+reproducible, standards-conformant batches without maintaining bespoke scripts
+per operator.
 
-License
--------
-Licensed under the [Apache-2.0](LICENSE) license.
+## Contents
 
-Requirements
-------------
-Python 3.10 or newer. Runtime dependencies (`pandas`, `pydantic`,
-`pycryptodome`, `numpy`) are installed automatically.
+- [What it generates](#what-it-generates)
+- [Standards](#standards)
+- [Installation](#installation)
+- [Quick start](#quick-start)
+- [Output formats](#output-formats)
+- [Configuration](#configuration)
+- [Identifier sequencing](#identifier-sequencing)
+- [Issuance ledger](#issuance-ledger)
+- [Security considerations](#security-considerations)
+- [Public API](#public-api)
+- [Development](#development)
+- [Contributing](#contributing)
+- [License](#license)
 
-Quick Start
------------
+## What it generates
 
-**1. Install**
+Each generated record describes one SIM card across 23 fields:
+
+| Group | Fields | Derivation |
+|---|---|---|
+| Identifiers | `ICCID`, `IMSI` | Sequenced from a configured starting value |
+| Authentication | `KI` | 128-bit random, from the OS CSPRNG |
+| | `OPC` | `AES_Ki(OP) ⊕ OP` |
+| | `EKI` | `AES_K4(Ki)` — Ki under the transport key |
+| | `ACC` | Access control class bitmask, from the last IMSI digit |
+| Cardholder | `PIN1`, `PIN2`, `PUK1`, `PUK2` | Fixed per batch or random per card |
+| Administrative | `ADM1`, `ADM6` | Fixed per batch or random per card |
+| OTA | `KIC1-3`, `KID1-3`, `KIK1-3` | 128-bit random per card |
+| Operator | `OP`, `K4` | Constant across the batch, from configuration |
+
+## Standards
+
+| Area | Reference |
+|---|---|
+| OPc derivation | 3GPP TS 35.206 (MILENAGE) |
+| `EF_IMSI`, `EF_ICCID`, `EF_ACC` encoding | 3GPP TS 31.102 |
+| Access control classes | 3GPP TS 22.011 |
+| ICCID numbering and check digit | ITU-T E.118 (Luhn) |
+| OTA keysets | ETSI TS 102 225 |
+
+The OPc implementation is verified against the TS 35.206 test vector on every
+CI run.
+
+## Installation
+
+Requires **Python 3.10 or newer**.
+
+```bash
+git clone https://github.com/hamzaqureshi5/gsm-data-generation_lib.git
+cd gsm-data-generation_lib
+pip install .
+```
+
+For development, install in editable mode:
 
 ```bash
 pip install -e .
 ```
 
-**2. Copy and edit the example config**
+Runtime dependencies (`pandas`, `pydantic`, `pycryptodome`, `numpy`) are
+resolved automatically.
+
+## Quick start
+
+Copy the example configuration and set your operator parameters:
 
 ```bash
 cp settings.example.json settings.json
 ```
 
-Open `settings.json` and set at minimum: `imsi`, `iccid`, `K4`, `op`, and `size`.
-
-**3. Generate SIM data**
+At minimum, set `imsi`, `iccid`, `K4`, `op` and `size`.
 
 ```python
 from gsm_data_generator import json_loader, DataGenerationScript
 
 config = json_loader("settings.json")
+
 script = DataGenerationScript(config)
 script.json_to_global_params()
 
 result_dfs, keys = script.generate_all_data()
+print(result_dfs["ELECT"].head())      # pandas DataFrame, one row per SIM
 
-elect_df = result_dfs["ELECT"]   # pandas DataFrame — one row per SIM
-print(elect_df.head())
-
-# Write the files and record the batch as issued
 written = script.write_outputs(result_dfs)
-print(written["ELECT"])          # <OUTPUT_FILES_DIR>/<FILE_NAME>.txt
+print(written["ELECT"])                # <OUTPUT_FILES_DIR>/<FILE_NAME>.txt
 ```
 
-Each `DataGenerationScript` owns its own parameter state, so several
-configurations can be generated in one process without interfering. Read a
-run's state through `script.params`; `Parameters.get_instance()` still returns
-a process-wide instance but is no longer where a script keeps its state.
+Each `DataGenerationScript` owns its own state, so independent configurations
+can be generated concurrently in one process. Read a run's parameters through
+`script.params`.
 
-**4. Verify your install works end-to-end**
+To confirm an installation end to end, including the TS 35.206 test vector:
 
 ```bash
 python verify.py
 ```
 
-Configuration Reference
------------------------
+## Output formats
 
-### DISP — generation parameters
+Three outputs are produced, each enabled independently and written with its own
+column separator:
+
+| Output | Consumer | Encoding | File |
+|---|---|---|---|
+| `ELECT` | Personalization equipment | Fields encoded to their EF representation | `<FILE_NAME>.txt` |
+| `SERVER` | HLR/HSS provisioning | Plain values | `<FILE_NAME>_server.txt` |
+| `GRAPH` | Laser marking | Plain values, clipped to print positions | `<FILE_NAME>_<OUTPUT_FILES_LASER_EXT>.txt` |
+
+`ELECT` applies GSM EF encoding: nibble-swapped ICCID with its Luhn check
+digit, length- and parity-prefixed IMSI, and `0xFF`-padded PIN.
+
+## Configuration
+
+A single JSON document with three sections. All fields are validated on load;
+invalid values raise a `ValidationError` naming the offending field rather than
+failing later in the pipeline.
+
+### `DISP` — generation parameters
 
 | Field | Type | Description |
 |---|---|---|
-| `elect_data_sep` | string | Column separator for ELECT output (e.g. `","`) |
-| `server_data_sep` | string | Column separator for SERVER output |
-| `graph_data_sep` | string | Column separator for GRAPH output |
-| `K4` | hex string, exactly **32, 48 or 64** chars | Transport key — used to encrypt Ki → eKI. The length selects the AES variant: 32 → AES-128, 48 → AES-192, 64 → AES-256. Other lengths are rejected at load time. |
-| `op` | hex string (exactly 32 chars) | Operator key — OPc = AES_Ki(OP) XOR OP |
-| `imsi` | exactly 15 digits | Starting IMSI. Only the MSIN portion is incremented — see [Identifier sequencing](#identifier-sequencing) |
-| `iccid` | 18–19 digits | Starting ICCID (**without** the Luhn check digit — it is computed and appended during encoding); incremented per SIM |
-| `pin1` / `pin2` | 4 digits | PIN value. Used as-is when `pin1_fix: true`; ignored when `false` (random generated) |
-| `puk1` / `puk2` | 8 digits | PUK value. Same fixed-vs-random logic via `puk1_fix` |
-| `adm1` / `adm6` | 8 printable ASCII chars | ADM codes. `adm1_fix: true` → fixed; `false` → random 8 digits per SIM |
-| `size` | integer (1–1,000,000) | Number of SIM records to generate |
-| `prod_check` | bool | Validate all parameters before generation (recommended: `true`). Raises `ConfigValidationError` listing every failing parameter. |
-| `elect_check` | bool | Enable ELECT (personalization) output |
-| `graph_check` | bool | Enable GRAPH (laser) output |
-| `server_check` | bool | Enable SERVER output |
-| `pin1_fix` / `puk1_fix` / `adm1_fix` … | bool | `true` = every SIM gets the fixed value above; `false` = unique random value per SIM |
+| `imsi` | 15 digits | Starting IMSI. See [Identifier sequencing](#identifier-sequencing) |
+| `iccid` | 18–19 digits | Starting ICCID, **without** the Luhn check digit — it is computed during encoding |
+| `op` | 32 hex chars | Operator key |
+| `K4` | 32, 48 or 64 hex chars | Transport key. Length selects the AES variant: 128, 192 or 256 |
+| `size` | 1–1,000,000 | Number of cards in the batch |
+| `pin1`, `pin2` | 4 digits | PIN value, used when the corresponding `*_fix` flag is set |
+| `puk1`, `puk2` | 8 digits | PUK value, same convention |
+| `adm1`, `adm6` | 8 printable ASCII | Administrative codes, same convention |
+| `pin1_fix`, `puk1_fix`, `adm1_fix`, … | bool | `true` applies the configured value to every card; `false` generates a unique random value per card |
+| `elect_check`, `graph_check`, `server_check` | bool | Enable each output |
+| `elect_data_sep`, `server_data_sep`, `graph_data_sep` | string | Column separator per output |
+| `prod_check` | bool | Validate every parameter before generating. Raises `ConfigValidationError` listing all failures |
 
-All string fields are character-set checked at load time: identifiers must be
-numeric, key material must be hexadecimal. Invalid values raise a Pydantic
-`ValidationError` naming the offending field instead of failing later inside
-the generation pipeline.
-
-### Identifier sequencing
-
-`imsi` and `iccid` are sequenced as fixed-width digit strings, not integers:
-
-- **Leading zeros are preserved.** A test-network IMSI such as
-  `001010000000001` stays 15 digits across the batch.
-- **The IMSI prefix is protected.** An IMSI is MCC (3 digits) + MNC (2 or 3) +
-  MSIN, so only the trailing 10 digits are incremented. A batch that would
-  carry into the first 5 digits is rejected rather than silently reassigning
-  the cards to a different operator — `410099999999998` with `size: 4` raises
-  instead of rolling over to `410100000000000`.
-- **ICCID is width-checked.** The whole value increments, but a batch that
-  would grow the ICCID past its configured length is rejected.
-
-> **Note:** the 5-digit protected prefix is a conservative bound that holds
-> under every numbering plan. Where the MNC is 3 digits (the North American
-> Numbering Plan) its final digit sits inside the incremented range and is not
-> covered; keep such batches well clear of the MSIN boundary.
-
-### PATHS — output file locations
+### `PATHS` — output locations
 
 | Field | Description |
 |---|---|
-| `FILE_NAME` | Base name for output files (no extension) |
-| `OUTPUT_FILES_DIR` | Directory where output files and the issuance ledger are written; created if missing |
-| `OUTPUT_FILES_LASER_EXT` | Suffix for laser/graph output filename |
+| `FILE_NAME` | Base name for output files, without extension |
+| `OUTPUT_FILES_DIR` | Destination directory, created if absent. Also holds the issuance ledger |
+| `OUTPUT_FILES_LASER_EXT` | Suffix distinguishing the laser output file |
 
-`script.write_outputs(result_dfs)` writes one separator-delimited text file per
-enabled output:
+### `PARAMETERS` — column selection
 
-| Output | File |
+| Field | Description |
 |---|---|
-| ELECT | `<FILE_NAME>.txt` |
-| SERVER | `<FILE_NAME>_server.txt` |
-| GRAPH | `<FILE_NAME>_<OUTPUT_FILES_LASER_EXT>.txt` |
+| `data_variables` | Ordered columns for `ELECT` |
+| `server_variables` | Ordered columns for `SERVER` |
+| `laser_variables` | Print position → `[column, type, "start-end"]` for `GRAPH` |
 
-### Issuance ledger
+Valid column names, case-sensitive:
 
-Re-running a configuration produces the **same** ICCID and IMSI sequences but
-**fresh** Ki values. Two cards would then carry the same ICCID with different
-keys and neither could be provisioned reliably.
+```
+ICCID  IMSI  OP    K4    PIN1  PUK1  PIN2  PUK2  KI    EKI   OPC   ADM1
+ADM6   ACC   KIC1  KID1  KIK1  KIC2  KID2  KIK2  KIC3  KID3  KIK3
+```
 
-`write_outputs` therefore records each batch in `.issuance_ledger.json` inside
-`OUTPUT_FILES_DIR` and refuses a batch that overlaps one already issued:
+`laser_variables` maps a print position to a slice of a field, so one column may
+appear at several positions:
+
+```json
+"laser_variables": {
+  "0": ["ICCID", "Normal", "0-3"],
+  "1": ["ICCID", "Normal", "4-7"],
+  "2": ["PIN1",  "Normal", "0-3"]
+}
+```
+
+Keys are non-negative integers applied in ascending numeric order, independent
+of their order in the file. Ranges are inclusive and must satisfy
+`start <= end`.
+
+## Identifier sequencing
+
+`imsi` and `iccid` are sequenced as fixed-width digit strings rather than
+integers, which preserves their structure:
+
+- **Leading zeros are retained.** A test-network IMSI of `001010000000001`
+  remains 15 digits across the batch.
+- **The IMSI operator prefix is protected.** An IMSI is MCC (3 digits) + MNC
+  (2–3) + MSIN, so only the trailing digits are incremented. A batch that would
+  carry into the first five digits is rejected rather than silently reassigning
+  cards to a different operator.
+- **ICCID width is enforced.** A batch that would extend the ICCID beyond its
+  configured length is rejected.
+
+> **Note**
+> The five-digit protected prefix is a conservative bound valid under every
+> numbering plan. Where the MNC is three digits, its final digit falls inside
+> the incremented range and is not covered; keep such batches clear of the MSIN
+> boundary.
+
+## Issuance ledger
+
+Re-running a configuration yields the **same** identifiers but **new** keys.
+Two cards would then share an ICCID while holding different Ki values, and
+neither could be provisioned reliably.
+
+`write_outputs` records every issued range in `.issuance_ledger.json` within
+`OUTPUT_FILES_DIR` and refuses any batch overlapping one already issued:
 
 ```
 IssuanceOverlapError: ICCID range 8991…000-8991…009 overlaps batch 1
@@ -172,118 +246,99 @@ IssuanceOverlapError: ICCID range 8991…000-8991…009 overlaps batch 1
 produce duplicate ICCIDs with different Ki values.
 ```
 
-Advance the starting `iccid`/`imsi` to continue, or pass
-`write_outputs(..., check_issuance=False)` to override deliberately. A batch
-counts as issued when it is **written**, so generating frames in memory never
-consumes a range.
+Advance the starting identifiers to continue, or pass `check_issuance=False` to
+override deliberately. A batch counts as issued when it is written, so
+in-memory generation never consumes a range.
 
-### PARAMETERS — output column selection
+## Security considerations
 
-| Field | Description |
-|---|---|
-| `data_variables` | Ordered list of columns in the ELECT output |
-| `server_variables` | Ordered list of columns in the SERVER output |
-| `laser_variables` | Dict mapping position index → `[column, type, "start-end"]` for GRAPH/laser output |
+This library produces live cryptographic key material. Treat its output as
+secret.
 
-Valid column names for `data_variables` / `server_variables` / `laser_variables`:
-`ICCID IMSI OP K4 PIN1 PUK1 PIN2 PUK2 KI EKI OPC ADM1 ADM6 ACC KIC1 KID1 KIK1 KIC2 KID2 KIK2 KIC3 KID3 KIK3`
+- **Key generation** uses Python's `secrets` module, backed by the operating
+  system CSPRNG. It is deliberately **not** seedable; a seeded generator may be
+  injected via `DataGenerationScript(config, data_generator=…)` for reproducible
+  test fixtures, and must never be used for cards intended for a real network.
+- **Ki need not leave the process in the clear.** The `EKI` column carries Ki
+  encrypted under the transport key `K4`; prefer it over `KI` in any output that
+  leaves your control.
+- **Output files are written unencrypted** with default permissions. Place
+  `OUTPUT_FILES_DIR` on protected storage and handle transfer out of band.
+- **Configuration contains `op` and `K4`.** Do not commit a populated
+  `settings.json`; the repository tracks only `settings.example.json`.
 
-Names are case-sensitive and validated at load time; an unknown column is
-rejected with the list of valid names.
-
-`laser_variables` example: `"0": ["ICCID", "Normal", "0-18"]` — position 0 takes chars 0–18 of ICCID.
-
-Each entry must be exactly `[column, type, range]`, where:
-
-- the **key** is the laser print position and must be a non-negative integer
-  string (`"0"`, `"1"`, …). Entries are applied in ascending numeric key order,
-  independent of the order they appear in the JSON file, and `"10"` correctly
-  follows `"9"`.
-- the **range** must be `"<start>-<end>"` with `start <= end`. A reversed range
-  (`"5-3"`) or an unparseable one (`"garbage"`) is rejected — previously these
-  silently produced an empty field or the whole value respectively.
-
-Features
---------
-- Cryptographic SIM parameter generation: Ki, OPc, eKI, ACC, PIN/PUK, OTA keys
-- Operator-configurable via a single JSON file
-- Three output formats: ELECT (personalization), SERVER (provisioning), GRAPH (laser)
-- Pydantic-validated config, rejecting malformed values at load time with the
-  offending field named
-- Structure-preserving identifier sequencing that refuses to carry into an
-  operator prefix
-- Issuance ledger that prevents the same ICCID range being issued twice
-- Per-run isolated state, so multiple configurations can be generated
-  concurrently in one process
-
-### Opt-in global behaviour
-
-Importing the library no longer replaces `sys.excepthook`. Applications that
-want the previous behaviour — suppressed backtraces for `DiagnosticError`
-unless `DATAGEN_BACKTRACE=1`, and termination of active multiprocessing
-children on an unhandled exception — should call it explicitly:
+## Public API
 
 ```python
-from gsm_data_generator import install_excepthook
-install_excepthook()
+from gsm_data_generator import (
+    DataGenerationScript,       # end-to-end pipeline
+    json_loader,                # load and validate configuration from a path
+    json_loader_2_ConfigHolder, # ... from a dict or JSON string
+    ConfigHolder,               # validated configuration
+    OutputWriter,               # write frames to delimited files
+    IssuanceLedger,             # issued-range tracking
+    DataGenerator,              # random Ki, OTA keys, PIN/PUK
+    DependentDataGenerator,     # OPc, eKI, ACC
+    CryptoUtils,                # AES-CBC and XOR primitives
+    EncodingUtils,              # GSM EF encode/decode
+    DataTransform,              # hex, byte and nibble conversion
+    DataProcessing,             # configuration and range parsing
+    DataFrameProcessor,         # column construction and encoding
+    Parameters, DataFrames,     # per-run state
+    DATAGENError,               # base exception
+    install_excepthook,         # opt-in diagnostic exception hook
+)
 ```
 
-Development
------------
+Importing the library has no global side effects. `install_excepthook()` opts
+into suppressed backtraces for `DiagnosticError` (unless `DATAGEN_BACKTRACE=1`)
+and termination of multiprocessing children on an unhandled exception.
+
+## Development
 
 ```bash
-# Editable install with the test tooling
 pip install -e .
-pip install pytest pytest-cov
+pip install pytest pytest-cov black mypy pandas-stubs
 
-# Run the suite (the invocation CI uses)
-pytest --maxfail=1 --disable-warnings -v
-
-# A single module
-pytest tests/python/algorithm/test_encrypt.py -v
-
-# Coverage
+pytest --maxfail=1 --disable-warnings -v          # full suite
+pytest tests/python/algorithm/test_encrypt.py -v  # one module
 pytest --cov=gsm_data_generator --cov-report=term-missing
-```
 
-Formatting and typing are enforced in CI, so check them before pushing:
-
-```bash
-pip install black mypy pandas-stubs
 black gsm_data_generator/ tests/python/ verify.py setup.py
 mypy gsm_data_generator/
 ```
 
-`pandas-stubs` is required for `mypy`: `mypy.ini` sets
-`ignore_missing_imports = False`, so an unstubbed `pandas` is a hard error.
+`pandas-stubs` is required: `mypy.ini` sets `ignore_missing_imports = False`,
+so unstubbed `pandas` is an error rather than a warning.
 
-To build and check the distributions locally:
+To build and validate the distributions:
 
 ```bash
 pip install build twine
-python -m build
-twine check dist/*
+python -m build && twine check dist/*
 ```
 
 ### Continuous integration
 
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs on every pull
 request, on pushes to `main`, and weekly — dependencies are unpinned, so the
-scheduled run surfaces upstream breakage without waiting for a PR.
+scheduled run surfaces upstream breakage without waiting for a change.
 
-| Job | Checks |
+| Job | Scope |
 |---|---|
 | `format` | `black --check` |
 | `typecheck` | `mypy` with `pandas-stubs` |
-| `test` | Python 3.10–3.13 on Ubuntu, plus 3.11 on Windows and macOS; `pip check`, the test suite with a coverage floor, and `verify.py` |
-| `package` | Builds the sdist and wheel, validates metadata, installs the wheel into a clean environment and smoke-tests it |
-| `ci-ok` | Aggregate gate — use this single check for branch protection |
+| `test` | Python 3.10–3.13 on Linux; 3.11 on Windows and macOS. Suite, coverage floor, and `verify.py` |
+| `package` | Builds sdist and wheel, validates metadata, installs the wheel into a clean environment and smoke-tests it |
+| `ci-ok` | Aggregate gate for branch protection |
 
-Contribute
-----------
-Data Generation is an open-source project. Contributions are welcome — please open an issue or pull request on GitHub.
+## Contributing
 
-History
--------
-Data Generation started as a research project for USIM/eSIM provisioning tooling and has gone through several rounds of redesign.
+Issues and pull requests are welcome. Before opening a pull request, please
+ensure `black`, `mypy` and the test suite pass locally — CI enforces all three.
 
+New source files should carry the Apache-2.0 header used throughout the tree.
+
+## License
+
+Licensed under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
The previous content read as internal notes: two empty placeholder links, two links to files that do not exist (CONTRIBUTORS.md, NEWS.md), mixed setext and ATX headings, and a History section written in the first person. It documented no security posture despite the library emitting live key material.

Restructured around what an evaluator needs, in order: what the tool produces, which specifications it implements, how to install it, a working example, then reference material. The existing header block and badge style are unchanged.

- A table of contents.
- A "What it generates" table covering all 23 fields and how each is derived.
- A "Standards" table citing 3GPP TS 35.206, TS 31.102, TS 22.011, ITU-T E.118 and ETSI TS 102 225, so conformance claims are checkable.
- An "Output formats" table stating the consumer and encoding of each output rather than only its file name.
- A "Security considerations" section: key generation is CSPRNG-backed and deliberately unseedable, EKI should be preferred over KI when output leaves your control, files are written unencrypted, and a populated settings.json holds op and K4 and must not be committed.
- A "Public API" block listing every export with its purpose.
- Contributing guidance stating what CI enforces.

Removed the dead and placeholder links. Every remaining link resolves: 14 anchors and two local paths. The import block under "Public API" is executed as a check; it covers all 17 exports besides __version__, with nothing documented that is not exported.