### PR TITLE
Add runnable examples for the public API

### DIFF
--- a/examples/01_quickstart.py
+++ b/examples/01_quickstart.py
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Generate one batch end to end, from a configuration file.
+
+Run:
+    python examples/01_quickstart.py
+"""
+
+import tempfile
+from pathlib import Path
+
+from gsm_data_generator import DataGenerationScript, json_loader
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def main() -> None:
+    config = json_loader(str(REPO_ROOT / "settings.example.json"))
+
+    # The example config writes to a relative "output" directory. Point it at a
+    # throwaway directory so this example leaves nothing behind; a real run
+    # would keep a stable directory, because the issuance ledger lives there
+    # and is what stops a batch being issued twice. See 05_issuance_ledger.py.
+    config.PATHS.OUTPUT_FILES_DIR = tempfile.mkdtemp(prefix="gsm-quickstart-")
+
+    script = DataGenerationScript(config)
+    script.json_to_global_params()
+
+    # Nothing is written yet: generate_all_data builds pandas frames in memory.
+    result_dfs, keys = script.generate_all_data()
+
+    print(f"batch size : {script.params.DATA_SIZE}")
+    print(f"frames     : {', '.join(sorted(result_dfs))}")
+    print(f"OP         : {keys['op']}")
+    print()
+
+    elect = result_dfs["ELECT"]
+    print(f"ELECT frame: {len(elect)} rows x {len(elect.columns)} columns")
+    print(elect[["ICCID", "IMSI", "KI", "OPC", "ACC"]].head().to_string(index=False))
+    print()
+
+    # write_outputs is the point at which the batch counts as issued.
+    written = script.write_outputs(result_dfs)
+    for output_type, path in sorted(written.items()):
+        print(f"{output_type:<7} -> {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_config_in_python.py
+++ b/examples/02_config_in_python.py
@@ -1,0 +1,108 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Build a configuration in Python instead of reading a settings file.
+
+Useful when the parameters come from a database, a web request or a test
+fixture rather than from disk. The dictionary is validated exactly as a file
+would be, so a bad K4 length or an unknown column name still fails here.
+
+Run:
+    python examples/02_config_in_python.py
+"""
+
+import tempfile
+
+from gsm_data_generator import (
+    DataGenerationScript,
+    json_loader_2_ConfigHolder,
+)
+from gsm_data_generator.error import DATAGENError
+
+
+def build_config(output_dir: str, size: int) -> dict:
+    return {
+        "DISP": {
+            "elect_data_sep": ",",
+            "server_data_sep": ",",
+            "graph_data_sep": ",",
+            # K4 is the transport key Ki is encrypted under; 32 or 64 hex chars.
+            "K4": "0000555500006666000077770000111100005555000066660000777700001111",
+            "op": "00001111000022220000333300004444",
+            "imsi": "410010000000001",
+            "iccid": "8944000000000000001",
+            "pin1": "1234",
+            "puk1": "12345678",
+            "pin2": "5678",
+            "puk2": "87654321",
+            "adm1": "AABBCCDD",
+            "adm6": "11223344",
+            "size": size,
+            "prod_check": True,
+            "elect_check": True,
+            "graph_check": False,
+            "server_check": True,
+            # *_fix true  -> every card in the batch shares the configured value
+            # *_fix false -> a fresh random value per card
+            "pin1_fix": True,
+            "puk1_fix": True,
+            "pin2_fix": True,
+            "puk2_fix": True,
+            "adm1_fix": False,
+            "adm6_fix": False,
+        },
+        "PATHS": {
+            "FILE_NAME": "batch_from_python",
+            "OUTPUT_FILES_DIR": output_dir,
+            "OUTPUT_FILES_LASER_EXT": "laser",
+        },
+        "PARAMETERS": {
+            "data_variables": ["IMSI", "ICCID", "KI", "OPC", "ACC", "PIN1", "PUK1"],
+            "server_variables": ["IMSI", "EKI", "ICCID", "ACC"],
+            "laser_variables": {},
+        },
+    }
+
+
+def main() -> None:
+    output_dir = tempfile.mkdtemp(prefix="gsm-python-config-")
+    config = json_loader_2_ConfigHolder(build_config(output_dir, size=5))
+
+    script = DataGenerationScript(config)
+    script.json_to_global_params()
+    result_dfs, _ = script.generate_all_data()
+
+    # ELECT carries KI in the clear for the personalization line; SERVER carries
+    # EKI instead, because the network side receives Ki under the transport key.
+    print("ELECT columns :", list(result_dfs["ELECT"].columns))
+    print("SERVER columns:", list(result_dfs["SERVER"].columns))
+    print()
+    print(result_dfs["SERVER"].head(3).to_string(index=False))
+    print()
+
+    # Validation is not advisory. An invalid K4 is rejected before any card is
+    # produced, rather than yielding a batch that fails at personalization.
+    broken = build_config(output_dir, size=5)
+    broken["DISP"]["K4"] = "ABCD"
+    try:
+        json_loader_2_ConfigHolder(broken)
+    except (DATAGENError, ValueError) as exc:
+        first_line = str(exc).strip().splitlines()[0]
+        print(f"rejected short K4 as expected: {first_line}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_key_derivation.py
+++ b/examples/03_key_derivation.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Derive OPc, EKI and ACC without running the batch pipeline.
+
+The derivations are plain functions on hex strings, so they can be used to
+check a single card, re-derive OPc for an existing Ki, or verify a vendor's
+output against this implementation.
+
+Run:
+    python examples/03_key_derivation.py
+"""
+
+from gsm_data_generator import CryptoUtils, DataGenerator, DependentDataGenerator
+
+
+def main() -> None:
+    # 1. Verify against the 3GPP TS 35.206 test vector. This is the same check
+    #    verify.py runs in CI; if it fails, nothing else here can be trusted.
+    ki = "465B5CE8B199B49FAA5F0A2EE238A6BC"
+    op = "CDC202D5123E20F62B6D676AC72CB318"
+    expected_opc = "CD63CB71954A9F4E48A5994E37A02BAF"
+
+    opc = DependentDataGenerator.calculate_opc(op, ki)
+    print("TS 35.206 vector")
+    print(f"  Ki       {ki}")
+    print(f"  OP       {op}")
+    print(f"  OPc      {opc}")
+    print(f"  match    {opc == expected_opc}")
+    print()
+
+    # 2. EKI is Ki encrypted under the transport key K4, which is what leaves
+    #    the building. Ki itself never travels in the server file.
+    k4 = "0000555500006666000077770000111100005555000066660000777700001111"
+    eki = DependentDataGenerator.calculate_eki(k4, ki)
+    print(f"EKI (Ki under K4)  {eki}")
+
+    # 3. ACC is the access control class bitmask, derived from the last IMSI
+    #    digit per 3GPP TS 22.011.
+    for imsi in ("410010000000001", "410010000000007", "410010000000000"):
+        acc = DependentDataGenerator.calculate_acc(imsi)
+        print(f"ACC for IMSI ...{imsi[-1]}   {acc}")
+    print()
+
+    # 4. The primitives underneath, if you need them directly.
+    ciphertext = CryptoUtils.aes_128_cbc_encrypt(op, ki)
+    xored = CryptoUtils.xor_str(bytes([0x0F]) * 4, bytes([0xF0]) * 4)
+    print(f"AES-128-CBC(OP, Ki) {ciphertext}")
+    print(f"XOR of 0F.. and F0.. {xored.hex().upper()}")
+    print()
+
+    # 5. Fresh secrets come from the OS CSPRNG, never a seeded PRNG.
+    print(f"random Ki           {DataGenerator.generate_ki()}")
+    print(f"random OTA key      {DataGenerator.generate_otas()}")
+    print(f"random K4 (32 hex)  {DataGenerator.generate_k4(32)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/04_encoding.py
+++ b/examples/04_encoding.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Encode and decode the GSM elementary files, and check an ICCID.
+
+EncodingUtils converts between human-readable values and the on-card byte
+layout defined in 3GPP TS 31.102. Every encoder here has a matching decoder,
+so a round trip is the quickest way to confirm a value is well-formed.
+
+Run:
+    python examples/04_encoding.py
+"""
+
+from gsm_data_generator import EncodingUtils
+
+
+def main() -> None:
+    # EF_IMSI: length prefix, parity nibble, then swapped BCD digits.
+    imsi = "410010000000001"
+    ef_imsi = EncodingUtils.enc_imsi(imsi)
+    print("EF_IMSI")
+    print(f"  plain    {imsi}")
+    print(f"  encoded  {ef_imsi}")
+    print(f"  decoded  {EncodingUtils.dec_imsi(ef_imsi)}")
+    print(f"  round trip ok: {EncodingUtils.dec_imsi(ef_imsi) == imsi}")
+    print()
+
+    # EF_ICCID: swapped BCD, no length prefix.
+    iccid = "8944000000000000001"
+    ef_iccid = EncodingUtils.enc_iccid(iccid)
+    print("EF_ICCID")
+    print(f"  plain    {iccid}")
+    print(f"  encoded  {ef_iccid}")
+    print(f"  decoded  {EncodingUtils.dec_iccid(ef_iccid)}")
+    print()
+
+    # PINs are ASCII, right-padded with 0xFF to eight bytes.
+    pin = "1234"
+    ef_pin = EncodingUtils.enc_pin(pin)
+    print("PIN")
+    print(f"  plain    {pin}")
+    print(f"  encoded  {ef_pin}")
+    print(f"  decoded  {EncodingUtils.dec_pin(ef_pin)}")
+    print()
+
+    # ITU-T E.118 check digit. An ICCID whose final digit is wrong will be
+    # rejected by personalization equipment, so validate before generating.
+    print("E.118 check digit (Luhn)")
+    body = "894400000000000000"  # 18 digits, check digit not yet appended
+    check_digit = EncodingUtils.calculate_luhn(body)
+    print(f"  body        {body}")
+    print(f"  check digit {check_digit}")
+    print(f"  full ICCID  {body}{check_digit}")
+
+    # Validating an ICCID you were given: recompute the digit and compare.
+    for candidate in ("8944000000000000001", "8944000000000000009"):
+        valid = EncodingUtils.calculate_luhn(candidate[:-1]) == int(candidate[-1])
+        print(f"  {candidate} valid: {valid}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05_issuance_ledger.py
+++ b/examples/05_issuance_ledger.py
@@ -1,0 +1,133 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Show the issuance ledger refusing to issue the same identifiers twice.
+
+Running one configuration twice yields identical ICCIDs and IMSIs but fresh,
+unrelated Ki values. The two card populations would collide in the HLR, which
+keys the subscriber by identifier. The ledger turns that into an error at
+write time rather than a field failure.
+
+Run:
+    python examples/05_issuance_ledger.py
+"""
+
+import tempfile
+
+from gsm_data_generator import DataGenerationScript, json_loader_2_ConfigHolder
+from gsm_data_generator.error import IssuanceOverlapError
+
+BASE = {
+    "DISP": {
+        "elect_data_sep": ",",
+        "server_data_sep": ",",
+        "graph_data_sep": ",",
+        "K4": "0000555500006666000077770000111100005555000066660000777700001111",
+        "op": "00001111000022220000333300004444",
+        "imsi": "410010000000001",
+        "iccid": "8944000000000000001",
+        "pin1": "1234",
+        "puk1": "12345678",
+        "pin2": "5678",
+        "puk2": "87654321",
+        "adm1": "AABBCCDD",
+        "adm6": "11223344",
+        "size": 10,
+        "prod_check": True,
+        "elect_check": True,
+        "graph_check": False,
+        "server_check": False,
+        "pin1_fix": True,
+        "puk1_fix": True,
+        "pin2_fix": True,
+        "puk2_fix": True,
+        "adm1_fix": False,
+        "adm6_fix": False,
+    },
+    "PATHS": {
+        "FILE_NAME": "batch",
+        "OUTPUT_FILES_DIR": "",
+        "OUTPUT_FILES_LASER_EXT": "laser",
+    },
+    "PARAMETERS": {
+        "data_variables": ["IMSI", "ICCID", "KI", "OPC", "ACC"],
+        "server_variables": ["IMSI", "EKI", "ICCID"],
+        "laser_variables": {},
+    },
+}
+
+
+def run_batch(output_dir: str, file_name: str, iccid: str, imsi: str) -> dict:
+    """Generate and write one batch, returning the paths written."""
+    config_dict = {
+        "DISP": {**BASE["DISP"], "iccid": iccid, "imsi": imsi},
+        "PATHS": {
+            **BASE["PATHS"],
+            "OUTPUT_FILES_DIR": output_dir,
+            "FILE_NAME": file_name,
+        },
+        "PARAMETERS": BASE["PARAMETERS"],
+    }
+    script = DataGenerationScript(json_loader_2_ConfigHolder(config_dict))
+    script.json_to_global_params()
+    result_dfs, _ = script.generate_all_data()
+    return script.write_outputs(result_dfs)
+
+
+def main() -> None:
+    output_dir = tempfile.mkdtemp(prefix="gsm-ledger-")
+    print(f"output directory: {output_dir}\n")
+
+    # First batch: ICCIDs ...001 through ...010.
+    run_batch(output_dir, "batch_001", "8944000000000000001", "410010000000001")
+    print("batch 1 written")
+
+    # Same starting identifiers again. Generation still succeeds — the ledger is
+    # only consulted at write time, because that is when cards become real.
+    try:
+        run_batch(output_dir, "batch_002", "8944000000000000001", "410010000000001")
+    except IssuanceOverlapError as exc:
+        print("batch 2 refused:")
+        print(f"  {exc}")
+    else:
+        raise AssertionError("expected the ledger to refuse this batch")
+    print()
+
+    # Advance past the issued range and the write succeeds.
+    run_batch(output_dir, "batch_003", "8944000000000000011", "410010000000011")
+    print("batch 3 written after advancing the starting identifiers\n")
+
+    # The ledger is a plain JSON file beside the output.
+    script = DataGenerationScript(
+        json_loader_2_ConfigHolder(
+            {
+                "DISP": BASE["DISP"],
+                "PATHS": {**BASE["PATHS"], "OUTPUT_FILES_DIR": output_dir},
+                "PARAMETERS": BASE["PARAMETERS"],
+            }
+        )
+    )
+    print(f"ledger file: {script.ledger.path}")
+    for record in script.ledger.records():
+        print(
+            f"  batch {record['batch']}: "
+            f"ICCID {record['iccid_start']}-{record['iccid_end']} "
+            f"({record['size']} cards)"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/06_reproducible_batch.py
+++ b/examples/06_reproducible_batch.py
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Inject a seeded generator so a batch is byte-for-byte reproducible.
+
+DataGenerationScript takes its randomness from an injected object, which makes
+tests able to assert on exact values. Two scripts in one process keep separate
+state, so independent configurations can also be generated concurrently.
+
+    WARNING
+    Keys from a seeded PRNG are predictable. This is for tests and fixtures
+    only. Never personalize cards for a real network with a seeded generator;
+    the default DataGenerator draws from the OS CSPRNG for that reason.
+
+Run:
+    python examples/06_reproducible_batch.py
+"""
+
+import random
+import tempfile
+
+from gsm_data_generator import DataGenerationScript, json_loader
+
+REPO_ROOT_SETTINGS = "settings.example.json"
+
+
+class SeededDataGenerator:
+    """Drop-in replacement for DataGenerator backed by a seeded PRNG.
+
+    Implements the surface DataGenerationScript actually calls: generate_ki,
+    generate_otas, generate_4_digit and generate_8_digit.
+    """
+
+    def __init__(self, seed: int) -> None:
+        self._rng = random.Random(seed)
+
+    def _hex16(self) -> str:
+        return self._rng.randbytes(16).hex().upper()
+
+    def generate_ki(self) -> str:
+        return self._hex16()
+
+    def generate_otas(self) -> str:
+        return self._hex16()
+
+    def generate_4_digit(self) -> str:
+        return f"{self._rng.randrange(10_000):04d}"
+
+    def generate_8_digit(self) -> str:
+        return f"{self._rng.randrange(100_000_000):08d}"
+
+
+def generate_kis(seed: int) -> list:
+    from pathlib import Path
+
+    config = json_loader(
+        str(Path(__file__).resolve().parent.parent / REPO_ROOT_SETTINGS)
+    )
+    config.PATHS.OUTPUT_FILES_DIR = tempfile.mkdtemp(prefix="gsm-seeded-")
+    config.DISP.size = 3
+
+    script = DataGenerationScript(config, data_generator=SeededDataGenerator(seed))
+    script.json_to_global_params()
+    result_dfs, _ = script.generate_all_data()
+    return list(result_dfs["ELECT"]["KI"])
+
+
+def main() -> None:
+    first = generate_kis(seed=1234)
+    second = generate_kis(seed=1234)
+    different = generate_kis(seed=9999)
+
+    print("seed 1234, run 1:")
+    for ki in first:
+        print(f"  {ki}")
+    print()
+    print(f"same seed reproduces the batch : {first == second}")
+    print(f"different seed differs         : {first != different}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,57 @@
+<!--- Licensed to the Apache Software Foundation (ASF) under one -->
+<!--- or more contributor license agreements.  See the NOTICE file -->
+<!--- distributed with this work for additional information -->
+<!--- regarding copyright ownership.  The ASF licenses this file -->
+<!--- to you under the Apache License, Version 2.0 (the -->
+<!--- "License"); you may not use this file except in compliance -->
+<!--- with the License.  You may obtain a copy of the License at -->
+
+<!---   http://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!--- Unless required by applicable law or agreed to in writing, -->
+<!--- software distributed under the License is distributed on an -->
+<!--- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY -->
+<!--- KIND, either express or implied.  See the License for the -->
+<!--- specific language governing permissions and limitations -->
+<!--- under the License. -->
+
+# Examples
+
+Runnable scripts covering the library's public API. Each is self-contained and
+writes only to a temporary directory, so they can be run in any order and leave
+nothing behind.
+
+```bash
+pip install -e .
+python examples/01_quickstart.py
+```
+
+| Script | Shows |
+|---|---|
+| [`01_quickstart.py`](01_quickstart.py) | Load a settings file, generate a batch, inspect the frame, write the output files |
+| [`02_config_in_python.py`](02_config_in_python.py) | Build and validate a configuration from a dict instead of a file |
+| [`03_key_derivation.py`](03_key_derivation.py) | Derive OPc, EKI and ACC directly; verify the TS 35.206 test vector |
+| [`04_encoding.py`](04_encoding.py) | Encode and decode `EF_IMSI`, `EF_ICCID` and PINs; compute an E.118 check digit |
+| [`05_issuance_ledger.py`](05_issuance_ledger.py) | Watch the ledger refuse to issue the same identifiers twice |
+| [`06_reproducible_batch.py`](06_reproducible_batch.py) | Inject a seeded generator for deterministic tests |
+
+## Two things worth knowing before you adapt these
+
+**Generating is not issuing.** `generate_all_data()` builds pandas frames in
+memory and touches nothing on disk. The batch counts as issued only when
+`write_outputs()` runs, which is where the issuance ledger is consulted and
+updated. That split is deliberate: you can generate freely, and the safety
+check applies at the moment cards become real.
+
+**The output directory is stateful.** The ledger lives in
+`PATHS.OUTPUT_FILES_DIR`, so a real deployment points that at a stable location
+and keeps it. These examples use throwaway directories, which means the
+duplicate-issuance protection resets on every run — convenient for a demo,
+wrong for production.
+
+## A note on the seeded generator
+
+`06_reproducible_batch.py` injects a PRNG so tests can assert on exact key
+values. Keys from a seeded PRNG are predictable. Use it for fixtures only; the
+default `DataGenerator` draws from the OS CSPRNG, which is what any card
+destined for a real network requires.


### PR DESCRIPTION
Six self-contained scripts covering the surface documented in the README, each writing only to a temporary directory so they can be run in any order and leave nothing behind:

  01_quickstart          settings file to written output files
  02_config_in_python    configuration from a dict, and its validation
  03_key_derivation      OPc, EKI and ACC, against the TS 35.206 vector
  04_encoding            EF_IMSI, EF_ICCID and PIN round trips, E.118 digit
  05_issuance_ledger     duplicate issuance refused, then accepted
  06_reproducible_batch  seeded generator injected for deterministic tests

The examples make two behaviours explicit that the API surface alone does not convey: that generate_all_data() touches no disk and the ledger applies only at write_outputs(), and that the ledger's state lives in the configured output directory, so a throwaway directory resets the duplicate protection.